### PR TITLE
Avoid reading property of undefined

### DIFF
--- a/bin/app.js
+++ b/bin/app.js
@@ -269,7 +269,7 @@ function processFoundRecords(searchObj, queryObj, records) {
             validData,
             fileSystemSafeName = normaliseRecordName(record.recordName),
             filePath = basePath + SLASH + record.folder + SLASH,
-            sys_id = record.recordData.sys_id || record.sys_id;
+            sys_id = record.recordData ? record.recordData.sys_id : record.sys_id;
 
         var fileName = fileSystemSafeName + '.' + record.fieldSuffix;
 


### PR DESCRIPTION
Avoid "TypeError: Cannot read property 'sys_id' of undefined" that occurs when trying to retrieve 
sys_id of record.recordData if record.recordData is not defined.
